### PR TITLE
Fixes wrong deepest breadcrumb found

### DIFF
--- a/frontend/class-breadcrumbs.php
+++ b/frontend/class-breadcrumbs.php
@@ -218,25 +218,15 @@ class WPSEO_Breadcrumbs {
 		}
 		unset( $term );
 
-		/*
-		As we could still have two subcategories, from different parent categories,
-		   let's pick the one with the lowest ordered ancestor.
-		*/
+		/* As we could still have two subcategories, from different parent categories,
+		let's pick the one with the lowest ordered ancestor. */
 		$parents_count = 0;
 		$term_order    = 9999; // Because ASC.
 		reset( $terms_by_id );
 		$deepest_term = current( $terms_by_id );
 		foreach ( $terms_by_id as $term ) {
 			$parents = $this->get_term_parents( $term );
-
 			if ( count( $parents ) >= $parents_count ) {
-				$parents_count = count( $parents );
-
-				// If higher count.
-				if ( count( $parents ) > $parents_count ) {
-					// Reset order.
-					$term_order = 9999;
-				}
 
 				$parent_order = 9999; // Set default order.
 				foreach ( $parents as $parent ) {
@@ -246,14 +236,15 @@ class WPSEO_Breadcrumbs {
 				}
 				unset( $parent );
 
-				// Check if parent has lowest order.
-				if ( $parent_order < $term_order ) {
+				// this will be true either if the current parents count is strictly bigger OR the current parent_order is lower
+				if ( count($parents) > $parents_count || $parent_order <= $term_order ) {
+					$parents_count = count( $parents );
 					$term_order   = $parent_order;
 					$deepest_term = $term;
 				}
+
 			}
 		}
-
 		return $deepest_term;
 	}
 


### PR DESCRIPTION
I removed some code such as

```php
				// if higher count
				if ( count( $parents ) > $parents_count ) {
					// reset order
					$term_order = 9999;
				}
```
since the line before this @236 was
```php
$parents_count = count($parents)
```
hence that if statement was unreachable code!

furthermore i had an example where a 0 parents category was choosen in favour of a 4 length deep category. This was due to the code @ line @235 ($parent_order was never set @ line 236 since $parent->term_order was never set)

So, at the end the first term was always the deepest one. Not sure why nobody found this a long time ago. 

Either way, i changed the last if ( line @240 ) to match such behavior.